### PR TITLE
Fix entrypoint typo 'metaextact'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
     ],
     entry_points={
         'console_scripts': [
-            'metaextact=metaextract.cmds:main',
+            'metaextract=metaextract.cmds:main',
         ],
     }
 )


### PR DESCRIPTION
It is 'metaextract'.