### PR TITLE
Convert sets used in entry_points to lists

### DIFF
--- a/metaextract/metaextract.py
+++ b/metaextract/metaextract.py
@@ -53,6 +53,10 @@ class metaextract(Command):
                 # dict_items objects can not be serialized with json
                 if data[key].__class__.__name__ == 'dict_items':
                     data[key] = list(data[key])
+                if key == 'entry_points' and isinstance(data[key], dict):
+                    for k, v in data[key].items():
+                        if isinstance(v, set):
+                            data[key][k] = list(v)
 
         # keep list ordered!
         for func in ['has_ext_modules']:


### PR DESCRIPTION
Some projects (like msm) use sets in the entry_points values, like:

    entry_points={
        'console_scripts': {
            'msm=msm.__main__:main'
        }
    }

This break the json.dumps call a few lines below in metaextract.py since
sets are not serializable in json.
This commit casts those sets to lists so the data can be written to a json
file and py2pack doesn't break when generating a spec file for those projects.