### PR TITLE
setup.py: drop setup_requires including setuptools and pytest-runner

### DIFF
--- a/metaextract/__init__.py
+++ b/metaextract/__init__.py
@@ -15,4 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
     author_email="thomasbechtold@jpberlin.de",
     url='http://github.com/toabctl/metaextract',
     packages=['metaextract'],
-    setup_requires=["setuptools", "pytest-runner"],
     cmdclass=metaextract.setup.get_cmdclass(),
     tests_require=["flake8", "pytest", "mock"],
     classifiers=[


### PR DESCRIPTION
setuptools should not be in setup_requires[0].
pytest-runner is not needed to run the tests and is deprecated[1].

[0] https://www.python.org/dev/peps/pep-0518/#rationale
[1] https://pypi.org/project/pytest-runner/

This fixes #13