### PR TITLE
Add initial support for packages without setup.py

### DIFF
--- a/metaextract/tests/fixtures/pyproject/README.md
+++ b/metaextract/tests/fixtures/pyproject/README.md
@@ -1,0 +1,1 @@
+long desc

--- a/metaextract/tests/fixtures/pyproject/pyproject.toml
+++ b/metaextract/tests/fixtures/pyproject/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling>=0.21.0"]
+build-backend = "hatchling.build"
+
+[project]
+requires-python = ">=2.6,!=3.0.*,!=3.1.*,!=3.2.*"
+name = "testpkg"
+version= "1.2.3"
+description = "desc"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "的å", email = "author@email.com" },
+]
+keywords = ["test", "pkg"]
+classifiers = [
+  "Intended Audience :: Developers",
+]
+dependencies = ["foo", "bar"]
+
+[project.optional-dependencies]
+extra1 = ["ex11", "ex12"]
+extra2 = ["ex21>=3.4", "ex22>=0.11.0,!=0.15.0"]
+
+[project.scripts]
+testpkgp1 = "testpkg:main"
+
+[tool.hatch.build.targets.sdist]
+[tool.hatch.build.targets.wheel]

--- a/metaextract/tests/test_metaextract.py
+++ b/metaextract/tests/test_metaextract.py
@@ -210,9 +210,34 @@ class TestMetaExtract(object):
              'tests_require': None,
              'version': '1'}
         ),
+        (
+            "pyproject",
+            {
+                'install_requires': ['bar', 'foo'], 'setup_requires': [],
+                'python_requires': '!=3.0.*,!=3.1.*,!=3.2.*,>=2.6',
+                'entry_points':
+                {
+                    'console_scripts': ['testpkgp1 = testpkg:main']
+                },
+                'extras_require': {
+                    'extra1': ['ex11', 'ex12'],
+                    'extra2': ['ex21>=3.4', 'ex22!=0.15.0,>=0.11.0']
+                },
+                'version': '1.2.3',
+                'name': 'testpkg',
+                'fullname': 'testpkg-1.2.3',
+                'description': 'desc',
+                'long_description': 'long desc\n',
+                'classifiers': ['Intended Audience :: Developers'],
+                'license': 'Apache-2.0',
+            }
+        ),
     ])
     def test_run_setup_py_from_dir(self, tmpdir, monkeypatch,
                                    fixture_name, expected_data):
+        if fixture_name == "pyproject" and sys.version_info < (3, 0):
+            pytest.skip("pyproject.toml is not supported for python2")
+
         # the given fixture name is the directory name in the tests/fixtures
         # dir. copy that fixtures dir to a temp dir and run _setup_py_from_dir
         # PBR_VERSION is needed for the PBR tests because the fixture are not

--- a/metaextract/utils.py
+++ b/metaextract/utils.py
@@ -95,8 +95,14 @@ def _setup_py_run_from_dir(root_dir, py_interpreter):
     data = {}
     with _enter_single_subdir(root_dir) as single_subdir:
         if not os.path.exists("setup.py"):
-            raise Exception("'setup.py' does not exist in '%s'" % (
-                single_subdir))
+            if not os.path.exists("pyproject.toml"):
+                raise Exception("'setup.py' does not exist in '%s'" % (
+                    single_subdir))
+
+            # Create it for pyproject.toml without setup.py
+            with open("setup.py", "w") as f:
+                f.write("from setuptools import setup\nsetup()\n")
+
         # generate a temporary json file which contains the metadata
         output_json = tempfile.NamedTemporaryFile()
         cmd = "%s setup.py -q --command-packages metaextract " \


### PR DESCRIPTION
Following the doc from setuptools, when there's no setup.py file it's possible to use a simple one with just the call to `setup()` that will get the data from pyproject.toml:
https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#configuring-setuptools-using-pyproject-toml-files

This should fix the issue in py2pack trying to generate from projects that doesn't provide a setup.py file:
https://github.com/openSUSE/py2pack/issues/159