### PR TITLE
Fix tests for setuptools >= 70 which removed tests_require

### DIFF
--- a/metaextract/tests/test_metaextract.py
+++ b/metaextract/tests/test_metaextract.py
@@ -148,121 +148,129 @@ class TestMetaExtract(object):
             meta_utils._setup_py_run_from_dir(tmpdir.strpath, sys.executable)
         assert tmpdir.strpath in str(e_info.value)
 
-    @pytest.mark.parametrize("fixture_name,expected_data", [
-        (
-            "setuptools_simple", dict(
-                [('entry_points', None),
-                 ('extras_require', {'extra1': ['pkg1']}),
-                 ('install_requires', ['bar', 'foo']),
-                 ('python_requires', None),
-                 ('setup_requires', []),
-                 ('has_ext_modules', None),
-                 ('scripts', None),
-                 ('data_files', None)] +
-                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []))
-        ),
-        (
-            "setuptools_simple_unicode", dict(
-                [('entry_points', None),
-                 ('extras_require', {
-                     'extra1': ['pkg1'], 'extra2': ['pkg2', 'pkg3']}),
-                 ('install_requires', ['bar', 'foo']),
-                 ('python_requires', None),
-                 ('setup_requires', []),
-                 ('has_ext_modules', None),
-                 ('scripts', None),
-                 ('data_files', None)] +
-                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []))
-        ),
-        (
-            "setuptools_simple_unicode_and_header", dict(
-                [('entry_points', None),
-                 ('extras_require', {}),
-                 ('install_requires', ['bar', 'foo']),
-                 ('python_requires', None),
-                 ('setup_requires', []),
-                 ('has_ext_modules', None),
-                 ('scripts', None),
-                 ('data_files', None)] +
-                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []))
-        ),
-        (
-            "setuptools_full", dict(
-                [('install_requires', ['bar', 'foo']),
-                 ('setup_requires', []),
-                 ('python_requires', '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'),
-                 ('has_ext_modules', None),
-                 ('scripts', ['scripts/testpkg']),
-                 ('data_files', [
-                     ['man/man1', ['doc/testpkg.1']],
-                     ['share/doc/testpgk',
-                      ['AUTHORS', 'LICENSE', 'README.rst']],
-                     ['share/doc/testpkg/html', ['doc/testpkg.html']],
-                 ])] +
-                ([('tests_require', ['testpkg1'])]
-                 if _HAS_TESTS_REQUIRE else []) +
-                [('entry_points', {
-                     'console_scripts': ['testpkgp1=testpkg:main']
-                 }),
-                 ('extras_require', {
-                     'extra1': ['ex11', 'ex12'],
-                     'extra2': ['ex21>=3.4', 'ex22!=0.15.0,>=0.11.0']
-                 }),
-                 ('version', '1.2.3'),
-                 ('name', 'testpkg'),
-                 ('fullname', 'testpkg-1.2.3'),
-                 ('description', 'desc'),
-                 ('long_description', 'long desc'),
-                 ('classifiers', ['Intended Audience :: Developers']),
-                 ('license', 'Apache-2.0')])
-        ),
-        (
-            "distutils_simple",
-            {'data_files': None, 'has_ext_modules': None, 'scripts': None,
-             'version': '1.0'}
-        ),
-        (
-            "distutils_with_extension",
-            {'data_files': None, 'has_ext_modules': True, 'scripts': None}
-        ),
-        (
-            "pbr_simple", dict(
-                [('entry_points', {'console_scripts': ['entry2 = pkg1:main']}),
-                 ('extras_require', {}),
-                 ('install_requires', []),
-                 ('python_requires', None),
-                 ('setup_requires', ['pbr>=1.0']),
-                 ('has_ext_modules', None),
-                 ('scripts', None),
-                 ('data_files', None)] +
-                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []) +
-                [('version', '1')])
-        ),
-        (
-            "pyproject",
-            {
-                'install_requires': ['bar', 'foo'], 'setup_requires': [],
-                'python_requires': '!=3.0.*,!=3.1.*,!=3.2.*,>=2.6',
-                'entry_points':
+    @pytest.mark.parametrize(
+        "fixture_name,expected_data,expected_tests_require", [
+            (
+                "setuptools_simple", {
+                    'entry_points': None,
+                    'extras_require': {'extra1': ['pkg1']},
+                    'install_requires': ['bar', 'foo'],
+                    'python_requires': None,
+                    'setup_requires': [],
+                    'has_ext_modules': None,
+                    'scripts': None, 'data_files': None},
+                None
+            ),
+            (
+                "setuptools_simple_unicode", {
+                    'entry_points': None, 'extras_require': {
+                        'extra1': ['pkg1'], 'extra2': ['pkg2', 'pkg3']},
+                    'install_requires': ['bar', 'foo'],
+                    'python_requires': None,
+                    'setup_requires': [],
+                    'has_ext_modules': None,
+                    'scripts': None, 'data_files': None},
+                None
+            ),
+            (
+                "setuptools_simple_unicode_and_header", {
+                    'entry_points': None, 'extras_require': {},
+                    'install_requires': ['bar', 'foo'],
+                    'python_requires': None,
+                    'setup_requires': [],
+                    'has_ext_modules': None,
+                    'scripts': None, 'data_files': None},
+                None
+            ),
+            (
+                "setuptools_full", {
+                    'install_requires': ['bar', 'foo'],
+                    'setup_requires': [],
+                    'python_requires':
+                        '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*',
+                    'has_ext_modules': None,
+                    'scripts': ['scripts/testpkg'],
+                    'data_files': [
+                        ['man/man1', ['doc/testpkg.1']],
+                        ['share/doc/testpgk',
+                         ['AUTHORS', 'LICENSE', 'README.rst']],
+                        ['share/doc/testpkg/html',
+                         ['doc/testpkg.html']],
+                    ], 'entry_points': {
+                        'console_scripts': [
+                            'testpkgp1=testpkg:main']
+                    },
+                    'extras_require': {
+                        'extra1': ['ex11', 'ex12'],
+                        'extra2': ['ex21>=3.4',
+                                   'ex22!=0.15.0,>=0.11.0']
+                    },
+                    'version': '1.2.3',
+                    'name': 'testpkg',
+                    'fullname': 'testpkg-1.2.3',
+                    'description': 'desc',
+                    'long_description': 'long desc',
+                    'classifiers': [
+                        'Intended Audience :: Developers'],
+                    'license': 'Apache-2.0',
+                },
+                ['testpkg1']
+            ),
+            (
+                "distutils_simple",
+                {'data_files': None, 'has_ext_modules': None,
+                 'scripts': None, 'version': '1.0'},
+                None
+            ),
+            (
+                "distutils_with_extension",
+                {'data_files': None, 'has_ext_modules': True,
+                 'scripts': None},
+                None
+            ),
+            (
+                "pbr_simple",
+                {'entry_points': {
+                    'console_scripts': ['entry2 = pkg1:main']},
+                 'extras_require': {}, 'install_requires': [],
+                 'python_requires': None,
+                 'setup_requires': ['pbr>=1.0'],
+                 'has_ext_modules': None,
+                 'scripts': None, 'data_files': None,
+                 'version': '1'},
+                None
+            ),
+            (
+                "pyproject",
                 {
-                    'console_scripts': ['testpkgp1 = testpkg:main']
+                    'install_requires': ['bar', 'foo'],
+                    'setup_requires': [],
+                    'python_requires':
+                        '!=3.0.*,!=3.1.*,!=3.2.*,>=2.6',
+                    'entry_points': {
+                        'console_scripts': [
+                            'testpkgp1 = testpkg:main']
+                    },
+                    'extras_require': {
+                        'extra1': ['ex11', 'ex12'],
+                        'extra2': ['ex21>=3.4',
+                                   'ex22!=0.15.0,>=0.11.0']
+                    },
+                    'version': '1.2.3',
+                    'name': 'testpkg',
+                    'fullname': 'testpkg-1.2.3',
+                    'description': 'desc',
+                    'long_description': 'long desc\n',
+                    'classifiers': [
+                        'Intended Audience :: Developers'],
+                    'license': 'Apache-2.0',
                 },
-                'extras_require': {
-                    'extra1': ['ex11', 'ex12'],
-                    'extra2': ['ex21>=3.4', 'ex22!=0.15.0,>=0.11.0']
-                },
-                'version': '1.2.3',
-                'name': 'testpkg',
-                'fullname': 'testpkg-1.2.3',
-                'description': 'desc',
-                'long_description': 'long desc\n',
-                'classifiers': ['Intended Audience :: Developers'],
-                'license': 'Apache-2.0',
-            }
-        ),
-    ])
+                None
+            ),
+        ])
     def test_run_setup_py_from_dir(self, tmpdir, monkeypatch,
-                                   fixture_name, expected_data):
+                                   fixture_name, expected_data,
+                                   expected_tests_require):
         if fixture_name == "pyproject" and sys.version_info < (3, 0):
             pytest.skip("pyproject.toml is not supported for python2")
 
@@ -278,3 +286,7 @@ class TestMetaExtract(object):
         for expected_key, expected_val in expected_data.items():
             assert expected_key in data['data']
             assert data['data'][expected_key] == expected_val
+        # setuptools >= 70 removed tests_require from Distribution
+        if _HAS_TESTS_REQUIRE:
+            assert data['data'].get('tests_require') == \
+                expected_tests_require

--- a/metaextract/tests/test_metaextract.py
+++ b/metaextract/tests/test_metaextract.py
@@ -21,11 +21,18 @@ import shutil
 import sys
 import tarfile
 
+import setuptools
+
 from metaextract import utils as meta_utils
 
 
 base_dir = os.path.dirname(__file__)
 fixtures_base_dir = os.path.join(base_dir, "fixtures")
+
+# setuptools >= 70 removed the tests_require attribute from Distribution
+_HAS_TESTS_REQUIRE = hasattr(
+    setuptools.Distribution({}), 'tests_require'
+)
 
 
 @pytest.fixture()
@@ -143,54 +150,71 @@ class TestMetaExtract(object):
 
     @pytest.mark.parametrize("fixture_name,expected_data", [
         (
-            "setuptools_simple", {
-                'entry_points': None, 'extras_require': {'extra1': ['pkg1']},
-                'install_requires': ['bar', 'foo'], 'python_requires': None,
-                'setup_requires': [], 'has_ext_modules': None,
-                'scripts': None, 'data_files': None, 'tests_require': None}
+            "setuptools_simple", dict(
+                [('entry_points', None),
+                 ('extras_require', {'extra1': ['pkg1']}),
+                 ('install_requires', ['bar', 'foo']),
+                 ('python_requires', None),
+                 ('setup_requires', []),
+                 ('has_ext_modules', None),
+                 ('scripts', None),
+                 ('data_files', None)] +
+                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []))
         ),
         (
-            "setuptools_simple_unicode", {
-                'entry_points': None, 'extras_require': {
-                    'extra1': ['pkg1'], 'extra2': ['pkg2', 'pkg3']},
-                'install_requires': ['bar', 'foo'], 'python_requires': None,
-                'setup_requires': [], 'has_ext_modules': None,
-                'scripts': None, 'data_files': None, 'tests_require': None}
+            "setuptools_simple_unicode", dict(
+                [('entry_points', None),
+                 ('extras_require', {
+                     'extra1': ['pkg1'], 'extra2': ['pkg2', 'pkg3']}),
+                 ('install_requires', ['bar', 'foo']),
+                 ('python_requires', None),
+                 ('setup_requires', []),
+                 ('has_ext_modules', None),
+                 ('scripts', None),
+                 ('data_files', None)] +
+                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []))
         ),
         (
-            "setuptools_simple_unicode_and_header", {
-                'entry_points': None, 'extras_require': {},
-                'install_requires': ['bar', 'foo'], 'python_requires': None,
-                'setup_requires': [], 'has_ext_modules': None,
-                'scripts': None, 'data_files': None, 'tests_require': None}
+            "setuptools_simple_unicode_and_header", dict(
+                [('entry_points', None),
+                 ('extras_require', {}),
+                 ('install_requires', ['bar', 'foo']),
+                 ('python_requires', None),
+                 ('setup_requires', []),
+                 ('has_ext_modules', None),
+                 ('scripts', None),
+                 ('data_files', None)] +
+                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []))
         ),
         (
-            "setuptools_full", {
-                'install_requires': ['bar', 'foo'], 'setup_requires': [],
-                'python_requires': '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*',
-                'has_ext_modules': None, 'scripts': ['scripts/testpkg'],
-                'data_files': [
-                    ['man/man1', ['doc/testpkg.1']],
-                    ['share/doc/testpgk',
-                     ['AUTHORS', 'LICENSE', 'README.rst']],
-                    ['share/doc/testpkg/html', ['doc/testpkg.html']],
-                ], 'tests_require': ['testpkg1'], 'entry_points':
-                {
-                    'console_scripts': ['testpkgp1=testpkg:main']
-                },
-                'extras_require': {
-                    'extra1': ['ex11', 'ex12'],
-                    'extra2': ['ex21>=3.4', 'ex22!=0.15.0,>=0.11.0']
-                },
-                'version': '1.2.3',
-                'name': 'testpkg',
-                'fullname': 'testpkg-1.2.3',
-                'description': 'desc',
-                'long_description': 'long desc',
-                'classifiers': ['Intended Audience :: Developers'],
-                'license': 'Apache-2.0',
-
-            }
+            "setuptools_full", dict(
+                [('install_requires', ['bar', 'foo']),
+                 ('setup_requires', []),
+                 ('python_requires', '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'),
+                 ('has_ext_modules', None),
+                 ('scripts', ['scripts/testpkg']),
+                 ('data_files', [
+                     ['man/man1', ['doc/testpkg.1']],
+                     ['share/doc/testpgk',
+                      ['AUTHORS', 'LICENSE', 'README.rst']],
+                     ['share/doc/testpkg/html', ['doc/testpkg.html']],
+                 ])] +
+                ([('tests_require', ['testpkg1'])]
+                 if _HAS_TESTS_REQUIRE else []) +
+                [('entry_points', {
+                     'console_scripts': ['testpkgp1=testpkg:main']
+                 }),
+                 ('extras_require', {
+                     'extra1': ['ex11', 'ex12'],
+                     'extra2': ['ex21>=3.4', 'ex22!=0.15.0,>=0.11.0']
+                 }),
+                 ('version', '1.2.3'),
+                 ('name', 'testpkg'),
+                 ('fullname', 'testpkg-1.2.3'),
+                 ('description', 'desc'),
+                 ('long_description', 'long desc'),
+                 ('classifiers', ['Intended Audience :: Developers']),
+                 ('license', 'Apache-2.0')])
         ),
         (
             "distutils_simple",
@@ -202,13 +226,17 @@ class TestMetaExtract(object):
             {'data_files': None, 'has_ext_modules': True, 'scripts': None}
         ),
         (
-            "pbr_simple",
-            {'entry_points': {'console_scripts': ['entry2 = pkg1:main']},
-             'extras_require': {}, 'install_requires': [],
-             'python_requires': None, 'setup_requires': ['pbr>=1.0'],
-             'has_ext_modules': None, 'scripts': None, 'data_files': None,
-             'tests_require': None,
-             'version': '1'}
+            "pbr_simple", dict(
+                [('entry_points', {'console_scripts': ['entry2 = pkg1:main']}),
+                 ('extras_require', {}),
+                 ('install_requires', []),
+                 ('python_requires', None),
+                 ('setup_requires', ['pbr>=1.0']),
+                 ('has_ext_modules', None),
+                 ('scripts', None),
+                 ('data_files', None)] +
+                ([('tests_require', None)] if _HAS_TESTS_REQUIRE else []) +
+                [('version', '1')])
         ),
         (
             "pyproject",


### PR DESCRIPTION
## Summary

- setuptools >= 70 removed the `tests_require` attribute from `Distribution` objects as part of the deprecation of `python setup.py test`
- The extraction code in `metaextract.py` already handles this correctly via `hasattr()` guards — when the attribute is absent, it's simply omitted from the output
- The **tests** were the problem: they unconditionally asserted `tests_require` would be present in the extracted metadata
- Added a runtime feature probe (`_HAS_TESTS_REQUIRE`) that checks whether the installed setuptools actually has the attribute, and conditionally includes it in test expectations

This ensures tests pass on both setuptools < 70 (where `tests_require` is present) and >= 70 (where it's removed).

## Test plan

- [x] All 17 tests pass with setuptools 82.0.1 (>= 70, no `tests_require`)
- [ ] Verify tests also pass with setuptools < 70 (e.g. 69.1.1) where `tests_require` is still present

Fixes #20